### PR TITLE
chore: Removed custom labels from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
         patterns: ["*"]
     commit-message:
       prefix: "chore(deps-dev)"
-    labels:
-      - "dependencies"
-      - "javascript"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -21,7 +18,3 @@ updates:
         patterns: ["*"]
     commit-message:
       prefix: "chore(deps-ci)"
-    labels:
-      - "dependencies"
-      - "github-actions"
-      - "ci"


### PR DESCRIPTION
## Description
This PR removed explicit labels from the Dependabot configuration to use GitHub's default labels for dependency updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined our dependency update process by simplifying label categorization.  
  This internal improvement helps maintain a cleaner and more efficient update notification system without impacting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->