### PR TITLE
chore: Ignore patch updates in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     groups:
       all:
         patterns: ["*"]


### PR DESCRIPTION
## Description
This PR updates Dependabot configuration to ignore all patch-level updates across all **npm** dependencies.
Example: Ignores updates like `1.2.3 → 1.2.4` but allows `1.2.3 → 1.3.0` or `2.0.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our automated dependency update process to ignore routine patch-level updates. This improvement reduces unnecessary update proposals and helps ensure that only more significant version changes prompt action. While these changes occur behind the scenes, they streamline our maintenance workflow and focus attention on impactful updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->