### PR TITLE
chore: Excluded .env file from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variable files
+.env


### PR DESCRIPTION
## Description
This PR updates `.gitignore` to exclude the `.env` file from version control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised project configuration to automatically ignore local files that store environment-specific settings, helping to keep sensitive information private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->